### PR TITLE
Support for specifying a URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ you can download my example projects into */home/user/docker-compose-ui/demo-pro
     -e GIT_REPO=https://github.com/nsano-rururu/docker-compose-ui.git \
     rururukenken/docker-compose-ui:1.13.2
 
+### Run from URL prefix
+
+Useful for running multiple applications under the same hostname, ie, Traefik console at `http://hostname.com/traefik/`, DCUI under `http://hostname.com/manage/`, etc.
+
+    docker run \
+    --name docker-compose-ui \
+    -p 5000:5000 \
+    -w /opt/docker-compose-projects/ \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e DOCKER_COMPOSE_UI_PREFIX=manage/docker \
+    rururukenken/docker-compose-ui:1.13.2
+
 ### Note about scaling services
 
 Note that some of the services provided by the demo projects are not "scalable" with `docker-compose scale SERVICE=NUM` because of published ports conflicts.

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ def prefix_route(route_function, prefix='', mask='{0}{1}'):
     Defines a new route function with a prefix.
     The mask argument is a `format string` formatted with, in that order:
       prefix, route
+    Pulled from https://stackoverflow.com/a/37878456 from user 7heo.tk
   '''
   def newroute(route, *args, **kwargs):
     '''New function to prefix the route'''

--- a/main.py
+++ b/main.py
@@ -22,9 +22,24 @@ from scripts.manage_project import manage
 API_V1 = '/api/v1/'
 YML_PATH = os.getenv('DOCKER_COMPOSE_UI_YML_PATH') or '.'
 COMPOSE_REGISTRY = os.getenv('DOCKER_COMPOSE_REGISTRY')
+STATIC_URL_PATH = '/' + (os.getenv('DOCKER_COMPOSE_UI_PREFIX') or '')
 
 logging.basicConfig(level=logging.INFO)
-app = Flask(__name__, static_url_path='')
+app = Flask(__name__, static_url_path=STATIC_URL_PATH)
+
+
+def prefix_route(route_function, prefix='', mask='{0}{1}'):
+  '''
+    Defines a new route function with a prefix.
+    The mask argument is a `format string` formatted with, in that order:
+      prefix, route
+  '''
+  def newroute(route, *args, **kwargs):
+    '''New function to prefix the route'''
+    return route_function(mask.format(prefix, route), *args, **kwargs)
+  return newroute
+
+app.route = prefix_route(app.route,prefix=STATIC_URL_PATH)
 
 def load_projects():
     """
@@ -489,4 +504,4 @@ def handle_generic_error(err):
 
 # run app
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', debug=False, threaded=True)
+    app.run(host='0.0.0.0', threaded=True)


### PR DESCRIPTION
This change allows a manager to specify a prefix at which the application should run, allowing one to run multiple applications including dcui under the same domain. See the updated readme for how to use.

This has been tested with and without specifying the `DOCKER_COMPOSE_UI_PREFIX` environment variable.

I created this change so I could run multiple services under my device's hostname, same port, so I could have Traefik manage them.